### PR TITLE
Nablarch 6系と同じDBで検証できるようにプロファイルを追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,38 @@
     <version>5-NEXT-SNAPSHOT</version>
   </parent>
 
+  <!-- Nablarch 5系と6系にて同じ手順で利用できるようにするため、6系でのみ検証対象のDBも独自に検証する -->
+  <profiles>
+    <profile>
+      <id>postgres174</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.postgresql</groupId>
+          <artifactId>postgresql</artifactId>
+          <version>42.7.2</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <properties>
+        <junit.additionalArgLine.db-profile>-Ddb-profile=postgres174</junit.additionalArgLine.db-profile>
+      </properties>
+    </profile>
+    <profile>
+      <id>db2121</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.ibm.db2</groupId>
+          <artifactId>jcc</artifactId>
+          <version>12.1.0.0</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <properties>
+        <junit.additionalArgLine.db-profile>-Ddb-profile=db2121</junit.additionalArgLine.db-profile>
+      </properties>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>com.nablarch.profile</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,13 @@
     <version>5-NEXT-SNAPSHOT</version>
   </parent>
 
-  <!-- Nablarch 5系と6系にて同じ手順で利用できるようにするため、6系でのみ検証対象のDBも独自に検証する -->
+  <!--
+    以下は本ツールの開発時に実行しているCI向けのprofileである（ツール利用時には不要であるため削除してもよい）。
+    本ツールはNablarch 5をベースに作成されている。Nablarch 6が既にリリースされいるが開発環境で利用するツールであることから、無理にマイグレーションを行っていない。
+    ただし、Nablarch 6をベースとしたアプリケーションの開発にも使用できるよう、動作確認対象のDBはNablarch 6に合わせている。
+    CIで使用する各DB用のprofileはnablarch-parentに定義されているが、本ツールでは上記の通りNablarch 5のnablarch-parentを親としているため、profileが不足している。
+    以下は不足しているprofileを利用するために定義している。
+  -->
   <profiles>
     <profile>
       <id>postgres174</id>


### PR DESCRIPTION
SQL ExecutorはNablarch 5を使用しているため、Nablarch 6系で検証を追加したDB用のプロファイルが存在せず、リリース時のCIでエラーが発生した。

Nablarch 6に上げる選択肢もあるが、組み込みJettyを独自に使用しておりバージョンアップに時間が掛かる可能性が高いことと、ブランチを分けて運用する点が問題となる。
SQL Executorはユーザーがcloneしてローカル実行する手順であるため、ブランチを分けて運用した場合は手順が変わることになってしまう。clone後にブランチを切り替えて実行してもらう運用は間違えやすそうであるため、極力同じ手順で実行するのが望ましいと判断した。

Nablarch 6系でJDBCラッパーに独自の機能を追加した場合はツール自体がNablarch 6系に対応する必要が出てくるが、現時点では共用できる見込みである。リリース直前ということもあり、まずはNablarcn 6系と同じDBで検証するためのプロファイルを追加し、あくまでツール独自に使用している機能範囲でのみNablarch 6系と同じDBで検証するようにプロファイルを追加した（[参考PR](https://github.com/nablarch/nablarch-parent/pull/51)）
